### PR TITLE
[Sonic] 16-bit window address support

### DIFF
--- a/__tests__/compressor-transformer.test.spec.js
+++ b/__tests__/compressor-transformer.test.spec.js
@@ -82,10 +82,10 @@ describe('CompressorTransformer', () => {
     compressorTransformer.on('finish', () => {
       expect(outputAccumulator).toMatchObject(
         Buffer.from([
-          0x1, 97,  // [a]
-          0x1, 97,  // [a,a]
-          0x1, 98,  // [a,a,b]
-          0x1, 97]) // [a,a,b,a]
+          0x01, 97,  // [a]
+          0x01, 97,  // [a,a]
+          0x01, 98,  // [a,a,b]
+          0x01, 97]) // [a,a,b,a]
       );
     });
 
@@ -104,10 +104,10 @@ describe('CompressorTransformer', () => {
     compressorTransformer.on('finish', () => {
       expect(outputAccumulator).toMatchObject(
         Buffer.from([
-          0x1, 97,  // [a]
-          0x1, 97,  // [a,a]
-          0x1, 97,  // [a,a,a]
-          0x1, 97]) // [a,a,a,a]
+          0x01, 97,  // [a]
+          0x01, 97,  // [a,a]
+          0x01, 97,  // [a,a,a]
+          0x01, 97]) // [a,a,a,a]
       );
     });
 
@@ -126,11 +126,11 @@ describe('CompressorTransformer', () => {
     compressorTransformer.on('finish', () => {
       expect(outputAccumulator).toMatchObject(
         Buffer.from([
-          0x1, 97,  // [a]
-          0x1, 97,  // [a,a]
-          0x1, 97,  // [a,a,a]
-          0x1, 97,  // [a,a,a,a]
-          0x05, 98, PREFIX_COMMAND_CHAR_CODE, 0x1, 44, 0x04]) // [4a,3a,2a,1a, [ 4, 3, 2, 1 ]+0a
+          0x01, 97,  // [a]
+          0x01, 97,  // [a,a]
+          0x01, 97,  // [a,a,a]
+          0x01, 97,  // [a,a,a,a]
+          0x06, 98, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x04, 0x00]) // [4a,3a,2a,1a, [ 4, 3, 2, 1 ]+0a
       );
     });
 
@@ -152,12 +152,12 @@ describe('CompressorTransformer', () => {
     compressorTransformer.on('finish', () => {
       expect(outputAccumulator).toMatchObject(
         Buffer.from([
-          0x1, 97,  // [a]
-          0x1, 97,  // [a,a]
-          0x1, 97,  // [a,a,a]
-          0x1, 97,  // [a,a,a,a]
-          0x05, 97, PREFIX_COMMAND_CHAR_CODE, 0x1, COMMA_CHAR_CODE, 0x04,  // [4a,3a,2a,1a, [ 4, 3, 2, 1 ]+0a
-          0x05, 97, PREFIX_COMMAND_CHAR_CODE, 0x1, COMMA_CHAR_CODE, 0x05]  // [5a,4a,3a,2a, [ 4, 3, 2, 1 ]+1a, [ 5, 4, 3, 2, 1 ]+0a
+          0x01, 97,  // [a]
+          0x01, 97,  // [a,a]
+          0x01, 97,  // [a,a,a]
+          0x01, 97,  // [a,a,a,a]
+          0x06, 97, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x04, 0x00,  // [4a,3a,2a,1a, [ 4, 3, 2, 1 ]+0a
+          0x06, 97, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x05, 0x00]  // [5a,4a,3a,2a, [ 4, 3, 2, 1 ]+1a, [ 5, 4, 3, 2, 1 ]+0a
         )
       );
     });
@@ -180,14 +180,14 @@ describe('CompressorTransformer', () => {
     compressorTransformer.on('finish', () => {
       expect(outputAccumulator).toMatchObject(
         Buffer.from([
-          0x1, 0x6c,    // [l]
-          0x1, 0x69,    // [l,i]
-          0x1, 0x73,    // [l,i,s]
-          0x1, 0x61,    // [l,i,s,a]
-          0x05, 0x6c, PREFIX_COMMAND_CHAR_CODE, 0x1, COMMA_CHAR_CODE, 0x04,  // [4l,3i,2s,1a, [ 4l, 3i, 2s, 1a ]+0l
-          0x1, 0x69,    // [5l,4i,3s,2a, [ 5l, 4i, 3s, 2a ]+1l, 0i
-          0x1, 0x73,    // [6l,5i,4s,3a, [ 6l, 5i, 4s, 3a ]+2l, 1i, 0s
-          0x1, 0x61]    // [7l,6i,5s,4a, [ 7l, 6i, 5s, 4a ]+3l, 2i, 1s, 0a
+          0x01, 0x6c,    // [l]
+          0x01, 0x69,    // [l,i]
+          0x01, 0x73,    // [l,i,s]
+          0x01, 0x61,    // [l,i,s,a]
+          0x06, 0x6c, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x04, 0x00,  // [4l,3i,2s,1a, [ 4l, 3i, 2s, 1a ]+0l
+          0x01, 0x69,    // [5l,4i,3s,2a, [ 5l, 4i, 3s, 2a ]+1l, 0i
+          0x01, 0x73,    // [6l,5i,4s,3a, [ 6l, 5i, 4s, 3a ]+2l, 1i, 0s
+          0x01, 0x61]    // [7l,6i,5s,4a, [ 7l, 6i, 5s, 4a ]+3l, 2i, 1s, 0a
         )
       );
     });
@@ -210,12 +210,12 @@ describe('CompressorTransformer', () => {
     compressorTransformer.on('finish', () => {
       expect(outputAccumulator).toMatchObject(
         Buffer.from([
-          0x1, 0x6c,    // [l]
-          0x1, 0x69,    // [l,i]
-          0x1, 0x73,    // [l,i,s]
-          0x1, 0x61,    // [l,i,s,a]
-          0x05, 0x6c, PREFIX_COMMAND_CHAR_CODE, 0x1, COMMA_CHAR_CODE, 0x04,   // [4l,3i,2s,1a, [ 4l, 3i, 2s, 1a ]+0l
-          0x05, 0x61, PREFIX_COMMAND_CHAR_CODE, 0x03, COMMA_CHAR_CODE, 0x06]   // [9l,8i,7s,6a,5l,4i,3s,2a,1l], [8i, 7s, 6a, 5l, 4i, 3s]+0a
+          0x01, 0x6c,    // [l]
+          0x01, 0x69,    // [l,i]
+          0x01, 0x73,    // [l,i,s]
+          0x01, 0x61,    // [l,i,s,a]
+          0x06, 0x6c, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x04, 0x00,   // [4l,3i,2s,1a, [ 4l, 3i, 2s, 1a ]+0l
+          0x06, 0x61, PREFIX_COMMAND_CHAR_CODE, 0x03, 0x00, 0x06, 0x00]   // [9l,8i,7s,6a,5l,4i,3s,2a,1l], [8i, 7s, 6a, 5l, 4i, 3s]+0a
         )
       );
     });
@@ -237,12 +237,12 @@ describe('CompressorTransformer', () => {
     compressorTransformer.on('finish', () => {
       expect(outputAccumulator).toMatchObject(
         Buffer.from([
-          0x1, 97,
-          0x1, 97,
-          0x1, 97,
-          0x1, 98,
-          0x1, 98,
-          0x1, 99])
+          0x01, 97,
+          0x01, 97,
+          0x01, 97,
+          0x01, 98,
+          0x01, 98,
+          0x01, 99])
       );
     });
 
@@ -261,8 +261,8 @@ describe('CompressorTransformer', () => {
     compressorTransformer.on('finish', () => {
       
       expect(outputAccumulator).toMatchObject(Buffer.from([
-        0x1, 194,
-        0x1, 163]));
+        0x01, 194,
+        0x01, 163]));
     });
 
     compressorTransformer.write('£');
@@ -285,13 +285,13 @@ describe('CompressorTransformer', () => {
       compressorTransformer.on('finish', () => {
         expect(outputAccumulator).toMatchObject(
           Buffer.from([
-            0x1, 97,
-            0x1, 97,
-            0x1, 97,
-            0x1, 97,
-            0x1, 97,
-            0x1, 97,
-            0x1, 97])
+            0x01, 97,
+            0x01, 97,
+            0x01, 97,
+            0x01, 97,
+            0x01, 97,
+            0x01, 97,
+            0x01, 97])
         );
       });
 

--- a/__tests__/decompressor-transformer.test.spec.js
+++ b/__tests__/decompressor-transformer.test.spec.js
@@ -5,7 +5,7 @@ const PREFIX_COMMAND_CHAR_CODE = 0x50;
 
 describe('DecompressorTransformer', () => {
   
-  it('inflates a to a', () => {
+  it('inflates `a`', () => {
     let decompressorTransformer = new DecompressorTransformer();
 
     let outputAccumulator = Buffer.from([]);
@@ -21,7 +21,24 @@ describe('DecompressorTransformer', () => {
     decompressorTransformer.end();
   });
 
-  it('inflates aaba', () => {
+  it('inflates `aaa` where the packet goes across to chunks', () => {
+    let decompressorTransformer = new DecompressorTransformer();
+
+    let outputAccumulator = Buffer.from([]);
+    decompressorTransformer.on('data', decompressedPacket => {
+      outputAccumulator = Buffer.concat([outputAccumulator, decompressedPacket]);
+    });
+
+    decompressorTransformer.on('finish', () => {
+      expect(outputAccumulator).toMatchObject(Buffer.from([0x80, 0x80, 0x80]));
+    });
+
+    decompressorTransformer.write(Buffer.from([0x01, 0x80, 0x06]));
+    decompressorTransformer.write(Buffer.from([0x80, 0x50, 0x01, 0x00, 0x01, 0x00]));
+    decompressorTransformer.end();
+  });
+
+  it('inflates `aaba`', () => {
     let decompressorTransformer = new DecompressorTransformer();
 
     let outputAccumulator = Buffer.from([]);
@@ -42,7 +59,7 @@ describe('DecompressorTransformer', () => {
     decompressorTransformer.end();
   });
 
-  it('inflates aaaa', () => {
+  it('inflates `aaaa`', () => {
     let decompressorTransformer = new DecompressorTransformer();
 
     let outputAccumulator = Buffer.from([]);
@@ -64,7 +81,7 @@ describe('DecompressorTransformer', () => {
     decompressorTransformer.end();
   });
 
-  it('inflates aaaaaaaab', () => {
+  it('inflates `aaaaaaaab`', () => {
     let decompressorTransformer = new DecompressorTransformer();
 
     let outputAccumulator = Buffer.from([]);
@@ -90,7 +107,7 @@ describe('DecompressorTransformer', () => {
     });
   });
 
-  it('inflates aaaaaaaaaaaaaaaa', () => {
+  it('inflates `aaaaaaaaaaaaaaaa`', () => {
     let decompressorTransformer = new DecompressorTransformer();
 
     let outputAccumulator = Buffer.from([]);
@@ -117,7 +134,7 @@ describe('DecompressorTransformer', () => {
     decompressorTransformer.end();
   });
 
-  it('inflates lisalisalisa', () => {
+  it('inflates `lisalisalisa`', () => {
     let decompressorTransformer = new DecompressorTransformer();
 
     let outputAccumulator = Buffer.from([]);
@@ -146,7 +163,7 @@ describe('DecompressorTransformer', () => {
     decompressorTransformer.end();
   });
 
-  it('inflates lisalisalisalisa', () => {
+  it('inflates `lisalisalisalisa`', () => {
     let decompressorTransformer = new DecompressorTransformer();
 
     let outputAccumulator = Buffer.from([]);

--- a/__tests__/decompressor-transformer.test.spec.js
+++ b/__tests__/decompressor-transformer.test.spec.js
@@ -106,12 +106,12 @@ describe('DecompressorTransformer', () => {
 
     decompressorTransformer.write(
       Buffer.from([
-        1, 97,  // [a]
-        1, 97,  // [a,a]
-        1, 97,  // [a,a,a]
-        1, 97,  // [a,a,a,a]
-        5, 97, PREFIX_COMMAND_CHAR_CODE, 0x01, COMMA_CHAR_CODE, 0x04,  // [4a,3a,2a,1a, [ 4, 3, 2, 1 ]+0a
-        5, 97, PREFIX_COMMAND_CHAR_CODE, 0x01, COMMA_CHAR_CODE, 0x05]  // [5a,4a,3a,2a, [ 4, 3, 2, 1 ]+1a, [ 5a, 4a, 3a, 2a, 1a ]+0a
+        0x01, 97,  // [a]
+        0x01, 97,  // [a,a]
+        0x01, 97,  // [a,a,a]
+        0x01, 97,  // [a,a,a,a]
+        0x06, 97, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x04, 0x00,  // [4a,3a,2a,1a, [ 4, 3, 2, 1 ]+0a
+        0x06, 97, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x05, 0x00]  // [5a,4a,3a,2a, [ 4, 3, 2, 1 ]+1a, [ 5a, 4a, 3a, 2a, 1a ]+0a
       )
     );
     decompressorTransformer.end();
@@ -133,14 +133,14 @@ describe('DecompressorTransformer', () => {
 
     decompressorTransformer.write(
       Buffer.from([
-        1, 0x6c,    // [l]
-        1, 0x69,    // [l,i]
-        1, 0x73,    // [l,i,s]
-        1, 0x61,    // [l,i,s,a]
-        5, 0x6c, PREFIX_COMMAND_CHAR_CODE, 0x01, COMMA_CHAR_CODE, 0x04,  // [4l,3i,2s,1a, [ 4l, 3i, 2s, 1a ]+0l
-        1, 0x69,    // [5l,4i,3s,2a, [ 5l, 4i, 3s, 2a ]+1l, 0i
-        1, 0x73,    // [6l,5i,4s,3a, [ 6l, 5i, 4s, 3a ]+2l, 1i, 0s
-        1, 0x61]    // [7l,6i,5s,4a, [ 7l, 6i, 5s, 4a ]+3l, 2i, 1s, 0a
+        0x01, 0x6c,    // [l]
+        0x01, 0x69,    // [l,i]
+        0x01, 0x73,    // [l,i,s]
+        0x01, 0x61,    // [l,i,s,a]
+        0x06, 0x6c, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x04, 0x00,  // [4l,3i,2s,1a, [ 4l, 3i, 2s, 1a ]+0l
+        0x01, 0x69,    // [5l,4i,3s,2a, [ 5l, 4i, 3s, 2a ]+1l, 0i
+        0x01, 0x73,    // [6l,5i,4s,3a, [ 6l, 5i, 4s, 3a ]+2l, 1i, 0s
+        0x01, 0x61]    // [7l,6i,5s,4a, [ 7l, 6i, 5s, 4a ]+3l, 2i, 1s, 0a
       )
     );
     decompressorTransformer.end();
@@ -166,8 +166,8 @@ describe('DecompressorTransformer', () => {
           1, 0x69,    // [l,i]
           1, 0x73,    // [l,i,s]
           1, 0x61,    // [l,i,s,a]
-          5, 0x6c, PREFIX_COMMAND_CHAR_CODE, 0x01, COMMA_CHAR_CODE, 0x04,   // [4l,3i,2s,1a, [ 4l, 3i, 2s, 1a ]+0l
-          5, 0x61, PREFIX_COMMAND_CHAR_CODE, 0x03, COMMA_CHAR_CODE, 0x06]   // [9l,8i,7s,6a,5l,4i,3s,2a,1l], [8i, 7s, 6a, 5l, 4i, 3s]+0a
+          0x06, 0x6c, PREFIX_COMMAND_CHAR_CODE, 0x01, 0x00, 0x04, 0x00,   // [4l,3i,2s,1a, [ 4l, 3i, 2s, 1a ]+0l
+          0x06, 0x61, PREFIX_COMMAND_CHAR_CODE, 0x03, 0x00, 0x06, 0x00]   // [9l,8i,7s,6a,5l,4i,3s,2a,1l], [8i, 7s, 6a, 5l, 4i, 3s]+0a
     ));
     decompressorTransformer.end();
   });
@@ -188,7 +188,7 @@ describe('DecompressorTransformer', () => {
     });
 
     decompressorTransformer.write(
-      Buffer.from([1, 97, 1, 97, 1, 97, 1, 97, 1, 98, 1, 99])
+      Buffer.from([0x01, 97, 0x01, 97, 0x01, 97, 0x01, 97, 0x01, 98, 0x01, 99])
     );
     decompressorTransformer.end();
   });

--- a/__tests__/deserialize-packet-from-binary.test.spec.js
+++ b/__tests__/deserialize-packet-from-binary.test.spec.js
@@ -74,7 +74,7 @@ describe('deserializePacketFromBinary', () => {
   });
 
   describe('when the input has a prefix field, but does not define a prefix', () => {
-    const input = 'aP';
+    const input = Buffer.from('aP');
     it('should throw an Error', () => {
       expect(() =>
         deserializePacketFromBinary(Buffer.from(input))
@@ -85,7 +85,7 @@ describe('deserializePacketFromBinary', () => {
   });
 
   describe('when the input has a unrecognized field', () => {
-    const input = 'aK';
+    const input = Buffer.from('aK');
     it('should throw an Error', () => {
       expect(() =>
         deserializePacketFromBinary(Buffer.from(input))

--- a/__tests__/deserialize-packet-from-binary.test.spec.js
+++ b/__tests__/deserialize-packet-from-binary.test.spec.js
@@ -44,7 +44,7 @@ describe('deserializePacketFromBinary', () => {
 
   describe('when the input has a prefix field', () => {
     beforeEach(() => {
-      result = deserializePacketFromBinary(Buffer.from([97, 80, 0x00, 44, 0x09, 0x00]));
+      result = deserializePacketFromBinary(Buffer.from([97, 80, 0x00, 0x00, 0x09, 0x00]));
     });
 
     it('should deserialize with the expected prefix', () => {
@@ -54,7 +54,7 @@ describe('deserializePacketFromBinary', () => {
 
   describe('when the input has prefix values above 10', () => {
     beforeEach(() => {
-      result = deserializePacketFromBinary(Buffer.from([97, 80, 10, 44, 123]));
+      result = deserializePacketFromBinary(Buffer.from([97, 80, 0x0A, 0x00, 0x7B, 0x00]));
     });
 
     it('should deserialize with the expected prefix', () => {
@@ -65,7 +65,7 @@ describe('deserializePacketFromBinary', () => {
 
   describe('when the input has prefix values above 255', () => {
     beforeEach(() => {
-      result = deserializePacketFromBinary(Buffer.from([97, 80, 0x01, 0x02, 44, 0x00, 0x04]));
+      result = deserializePacketFromBinary(Buffer.from([97, 80, 0x01, 0x02, 0x00, 0x04]));
     });
 
     it('should deserialize with the expected prefix', () => {

--- a/__tests__/serialize-packet-to-binary.test.spec.js
+++ b/__tests__/serialize-packet-to-binary.test.spec.js
@@ -83,7 +83,7 @@ describe('serializePacketToBinary', () => {
     });
 
     it('should return a binary representation of the packet', () => {
-      expect(result).toMatchObject(Buffer.from([112, 80, 1, 44, 3]));
+      expect(result).toMatchObject(Buffer.from([112, 80, 0x01, 0x00, 0x03, 0x00]));
     });
   });
 

--- a/samples/filecompress.js
+++ b/samples/filecompress.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env time node --prof
 import { CompressorTransformer } from '../lib/compressor-transformer';
 import { DecompressorTransformer } from '../lib/decompressor-transformer';
 

--- a/samples/find-index-of-subarray-profile.js
+++ b/samples/find-index-of-subarray-profile.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env time node --prof
-import locateToken from '../lib/locate-token.js';
-import { SSL_OP_SSLEAY_080_CLIENT_DH_BUG } from 'constants';
+import findIndexOfSubarray from '../lib/find-index-of-subarray.js';
 
 let history = [];
 let buffer = [];
@@ -13,4 +12,4 @@ for (let i = 0; i < 1280; ++i) {
   buffer.push(String.fromCharCode(Math.random() * 254));
 }
 
-locateToken(history, buffer);
+findIndexOfSubarray(history, buffer);

--- a/src/deserialize-packet-from-binary.js
+++ b/src/deserialize-packet-from-binary.js
@@ -1,6 +1,5 @@
 const invalidFatalInput = input => !input;
 
-const COMMA_CHAR_CODE = 0x2c;
 const PREFIX_COMMAND_CHAR_CODE = 0x50;
 
 const hasPrefixField = input => {
@@ -29,7 +28,7 @@ const deserializePacketFromBinary = serialisedBuffer => {
     throw new Error(
       `Invalid compression serialisation stream command for input '${serialisedBuffer}'`
     );
-  }
+  }      
 
   return output;
 };

--- a/src/deserialize-packet-from-binary.js
+++ b/src/deserialize-packet-from-binary.js
@@ -7,17 +7,8 @@ const hasPrefixField = input => {
   return input.length >= 5 && input[1] === PREFIX_COMMAND_CHAR_CODE;
 }
 const readPrefixValue = field => {
-  if (field.lastIndexOf(COMMA_CHAR_CODE) - 1 < 0) {
-    throw new Error(field.lastIndexOf(COMMA_CHAR_CODE) + '   [' + field + ']');
-  }
-
-  let delimPosition = field.lastIndexOf(COMMA_CHAR_CODE);
-  if (delimPosition >= field.length - 1) {
-    delimPosition = field.indexOf(COMMA_CHAR_CODE);
-  }
-
-  let prefixValue1 = field.readUIntLE(0, delimPosition);
-  let prefixValue2 = field.readUIntLE(delimPosition + 1, field.length - delimPosition - 1);
+  let prefixValue1 = field.readUInt16LE(0);
+  let prefixValue2 = field.readUInt16LE(2);
   return [prefixValue1, prefixValue2];
 };
 

--- a/src/serialize-packet-to-binary.js
+++ b/src/serialize-packet-to-binary.js
@@ -1,3 +1,5 @@
+import unpackIntegerByte from './unpack-integer-to-byte';
+
 const validTokenField = input => typeof input.t !== String && input.t;
 
 const prefixFieldExists = input => input.p !== undefined;
@@ -21,10 +23,8 @@ const serializePacketToBinary = compressionPackets => {
     prefixFieldExists(compressionPackets) &&
     validPrefixField(compressionPackets)
   ) {
-    let prefix = Buffer.from(
-      [80, compressionPackets.p[0], 44, compressionPackets.p[1]]
-    );
-    output = Buffer.concat([output, prefix]);
+
+    output = Buffer.concat([output, Buffer.from([80]), unpackIntegerByte(compressionPackets.p[0], 2), unpackIntegerByte(compressionPackets.p[1], 2)]);
   }
 
   return output;


### PR DESCRIPTION
Adds support for 16-bit window addresses. The prefix field no longer uses a comma separator, it instead stores the address using four fixed bytes. The first two bytes store the start position, the last two bytes store the length. The prefix fields are stored as 16-bit unsigned integers with little endian byte order. 

The packet size field implementation has been modified to be more explicit about the exact format. It always gets stored as a 8-bit integer.